### PR TITLE
Provide internal MIDI export fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,7 @@ python main.py
 - `song_analyzer/midi_export.py` – MIDI export utility
 
 ## Notes
-This project requires packages such as `librosa`, `PyQt5`, `pyqtgraph` and `pretty_midi` which
-may need system dependencies to install. The application does not provide audio playback.
+This project requires packages such as `librosa`, `PyQt5` and `pyqtgraph` which may need
+system dependencies to install. MIDI export can optionally use `pretty_midi` if it is
+available, but a minimal fallback implementation is bundled with the project. The
+application does not provide audio playback.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 librosa
 PyQt5
 pyqtgraph
-pretty_midi
+# pretty_midi  # optional, a lightweight fallback is included

--- a/song_analyzer/midi_export.py
+++ b/song_analyzer/midi_export.py
@@ -1,8 +1,25 @@
-import pretty_midi
-from .analysis import SegmentAnalysis
+"""MIDI export utilities.
+
+This module attempts to use the external ``pretty_midi`` package for writing
+MIDI files.  If the dependency is unavailable we fall back to a very small
+built-in implementation that supports the subset of features needed by the
+application.  The fallback is intentionally lightweight so that users can run
+the project without installing additional packages.
+"""
+
+from typing import Iterable, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type hinting only
+    from .analysis import SegmentAnalysis
+
+try:  # pragma: no cover - optional dependency
+    import pretty_midi  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - used when dependency missing
+    from . import pretty_midi_stub as pretty_midi
 
 
-def export_midi(segments, path: str) -> None:
+def export_midi(segments: Iterable['SegmentAnalysis'], path: str) -> None:
+    """Export a collection of :class:`SegmentAnalysis` objects to a MIDI file."""
     pm = pretty_midi.PrettyMIDI()
     instrument = pretty_midi.Instrument(program=0)
     for seg in segments:
@@ -10,6 +27,8 @@ def export_midi(segments, path: str) -> None:
             pitch = pretty_midi.note_name_to_number(note.name)
             start = note.start
             end = note.start + note.duration
-            instrument.notes.append(pretty_midi.Note(velocity=100, pitch=pitch, start=start, end=end))
+            instrument.notes.append(
+                pretty_midi.Note(velocity=100, pitch=pitch, start=start, end=end)
+            )
     pm.instruments.append(instrument)
     pm.write(path)

--- a/song_analyzer/pretty_midi_stub.py
+++ b/song_analyzer/pretty_midi_stub.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+"""A minimal stand-in for :mod:`pretty_midi`.
+
+This module implements the tiny subset of the ``pretty_midi`` API that is
+required by :func:`song_analyzer.midi_export.export_midi`.  It allows the
+project to export very simple MIDI files without the third‑party dependency.
+The implementation is intentionally lightweight and does not aim to be a full
+MIDI solution.
+"""
+
+from dataclasses import dataclass
+from typing import List
+import struct
+
+# Mapping from note names to semitone numbers within an octave
+_NOTE_MAP = {
+    'C': 0, 'C#': 1, 'Db': 1, 'D': 2, 'D#': 3, 'Eb': 3, 'E': 4,
+    'F': 5, 'F#': 6, 'Gb': 6, 'G': 7, 'G#': 8, 'Ab': 8, 'A': 9,
+    'A#': 10, 'Bb': 10, 'B': 11,
+}
+
+
+def note_name_to_number(name: str) -> int:
+    """Convert a note name (e.g. ``C4``) to a MIDI note number."""
+    note = name[:-1]
+    octave = int(name[-1])
+    return _NOTE_MAP[note] + 12 * (octave + 1)
+
+
+def _var_len(value: int) -> bytes:
+    """Encode an integer as a MIDI variable-length quantity."""
+    buffer = value & 0x7F
+    result = bytearray()
+    while value >> 7:
+        value >>= 7
+        buffer <<= 8
+        buffer |= ((value & 0x7F) | 0x80)
+    while True:
+        result.append(buffer & 0xFF)
+        if buffer & 0x80:
+            buffer >>= 8
+        else:
+            break
+    return bytes(result)
+
+
+@dataclass
+class Note:
+    velocity: int
+    pitch: int
+    start: float
+    end: float
+
+
+class Instrument:
+    """Collection of notes played by a single instrument."""
+
+    def __init__(self, program: int = 0) -> None:
+        self.program = program
+        self.notes: List[Note] = []
+
+
+class PrettyMIDI:
+    """Very small MIDI file writer compatible with ``pretty_midi`` usage."""
+
+    def __init__(self, tempo: float = 120.0, ticks_per_beat: int = 480) -> None:
+        self.tempo = tempo
+        self.ticks_per_beat = ticks_per_beat
+        self.instruments: List[Instrument] = []
+
+    def _seconds_to_ticks(self, seconds: float) -> int:
+        return int(seconds * self.ticks_per_beat * self.tempo / 60.0)
+
+    def write(self, path: str) -> None:
+        events = []
+        # Build events from all instruments
+        for inst in self.instruments:
+            events.append((0, 0, bytes([0xC0, inst.program])))  # program change
+            for note in inst.notes:
+                start = self._seconds_to_ticks(note.start)
+                end = self._seconds_to_ticks(note.end)
+                events.append((start, 1, bytes([0x90, note.pitch, note.velocity])))
+                events.append((end, 2, bytes([0x80, note.pitch, 0])))
+
+        events.sort(key=lambda x: (x[0], x[1]))
+        track = bytearray()
+
+        # tempo meta event
+        tempo_us = int(60_000_000 / self.tempo)
+        track += _var_len(0) + b"\xFF\x51\x03" + tempo_us.to_bytes(3, "big")
+
+        last = 0
+        for tick, _, data in events:
+            delta = tick - last
+            track += _var_len(delta) + data
+            last = tick
+
+        track += _var_len(0) + b"\xFF\x2F\x00"  # end of track
+
+        header = b"MThd" + struct.pack(">IHHH", 6, 0, 1, self.ticks_per_beat)
+        track_chunk = b"MTrk" + struct.pack(">I", len(track)) + track
+
+        with open(path, "wb") as fh:
+            fh.write(header + track_chunk)


### PR DESCRIPTION
## Summary
- avoid hard dependency on pretty_midi by falling back to a small built-in writer
- document optional pretty_midi usage and update requirements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688df0b76de883239d2e7da70a30ca34