### PR TITLE
Require librosa 0.10 or newer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-librosa
+librosa>=0.10
 PyQt5
 pyqtgraph
 # pretty_midi  # optional, a lightweight fallback is included


### PR DESCRIPTION
## Summary
- pin librosa dependency to version 0.10 or newer in requirements

## Testing
- `pip install -r requirements.txt`
- `python - <<'PY'
import librosa
print(librosa.__version__)
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688df2b4f4188323bea5c79c4c8869e5