### PR TITLE
Handle missing librosa key estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,6 @@ python main.py
 This project requires packages such as `librosa`, `PyQt5` and `pyqtgraph` which may need
 system dependencies to install. MIDI export can optionally use `pretty_midi` if it is
 available, but a minimal fallback implementation is bundled with the project. The
-application does not provide audio playback.
+application does not provide audio playback. Accurate key detection relies on
+`librosa>=0.10`; older versions fall back to a simple chroma-profile correlation and may
+return `"Unknown"` when the key cannot be determined.


### PR DESCRIPTION
## Summary
- Add fallback key detection when `librosa.key.estimate_key` is unavailable
- Document required `librosa>=0.10` and fallback behavior in README

## Testing
- `python -m py_compile song_analyzer/analysis.py`
- `python -m py_compile song_analyzer/*.py`


------
https://chatgpt.com/codex/tasks/task_e_688df44d3f14832392984a48a92e36c1