### PR TITLE
Fix piano roll rect item import for PyQt5 and enhance GUI

### DIFF
--- a/song_analyzer/piano_roll.py
+++ b/song_analyzer/piano_roll.py
@@ -1,5 +1,5 @@
 import pyqtgraph as pg
-from pyqtgraph.Qt import QtGui
+from pyqtgraph.Qt import QtWidgets
 import librosa
 
 pg.setConfigOption('background', '#121212')
@@ -26,7 +26,7 @@ class PianoRollWidget(pg.GraphicsLayoutWidget):
             brush = pg.mkBrush(*color)
             for note in seg.notes:
                 pitch = librosa.note_to_midi(note.name)
-                rect = QtGui.QGraphicsRectItem(note.start, pitch, note.duration, 1)
+                rect = QtWidgets.QGraphicsRectItem(note.start, pitch, note.duration, 1)
                 rect.setBrush(brush)
                 rect.setPen(pg.mkPen(None))
                 self.plot.addItem(rect)


### PR DESCRIPTION
## Summary
- fix piano roll to use QtWidgets.QGraphicsRectItem instead of QtGui.QGraphicsRectItem
- show loading progress bar during analysis and export
- add helpful tooltips to drag/drop area, buttons, and displays

## Testing
- `python -m py_compile song_analyzer/gui.py`
- `python -m py_compile song_analyzer/piano_roll.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688df5e77d948323b537b60cfea99397