### PR TITLE
Add percussion detection and visualization

### DIFF
--- a/song_analyzer/gui.py
+++ b/song_analyzer/gui.py
@@ -31,6 +31,7 @@ class MainWindow(QtWidgets.QMainWindow):
         accent = 'rgb(100,51,162)'
         self.file_path = None
         self.segments = []
+        self.percussion = []
 
         central = QtWidgets.QWidget()
         layout = QtWidgets.QVBoxLayout(central)
@@ -58,7 +59,7 @@ class MainWindow(QtWidgets.QMainWindow):
         layout.addWidget(self.info)
 
         self.piano = PianoRollWidget()
-        self.piano.setToolTip('Visual piano roll of detected notes')
+        self.piano.setToolTip('Visual piano roll of detected notes and percussion')
         layout.addWidget(self.piano)
 
         self.progress = QtWidgets.QProgressBar()
@@ -87,7 +88,7 @@ class MainWindow(QtWidgets.QMainWindow):
         dialog.setCancelButton(None)
         dialog.show()
         QtWidgets.QApplication.processEvents()
-        self.segments = analyze_audio(self.file_path)
+        self.segments, self.percussion = analyze_audio(self.file_path)
         name = os.path.basename(self.file_path)
         info_lines = [f'File: {name}']
         for seg in self.segments:
@@ -95,7 +96,7 @@ class MainWindow(QtWidgets.QMainWindow):
             line = f"{seg.name}: Key {seg.key}, Tempo {seg.tempo:.1f} BPM\nNotes: {notes}"
             info_lines.append(line)
         self.info.setText('\n\n'.join(info_lines))
-        self.piano.display(self.segments)
+        self.piano.display(self.segments, self.percussion)
         dialog.close()
 
     def export(self):
@@ -112,7 +113,8 @@ class MainWindow(QtWidgets.QMainWindow):
     def reset(self):
         self.file_path = None
         self.segments = []
+        self.percussion = []
         self.setWindowTitle('Song Analyzer')
         self.info.clear()
-        self.piano.plot.clear()
+        self.piano.clear()
         self.progress.setVisible(False)

--- a/song_analyzer/piano_roll.py
+++ b/song_analyzer/piano_roll.py
@@ -1,6 +1,8 @@
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtWidgets
 import librosa
+from typing import List
+from .analysis import SegmentAnalysis, PercussionEvent
 
 pg.setConfigOption('background', '#121212')
 pg.setConfigOption('foreground', 'w')
@@ -8,14 +10,25 @@ pg.setConfigOption('foreground', 'w')
 class PianoRollWidget(pg.GraphicsLayoutWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.plot = self.addPlot()
-        self.plot.setLabel('bottom', 'Time', units='s')
-        self.plot.setLabel('left', 'Pitch')
-        self.plot.setLimits(xMin=0, yMin=0, yMax=127)
-        self.plot.showGrid(x=True, y=True, alpha=0.3)
+        self.melody_plot = self.addPlot(row=0, col=0)
+        self.melody_plot.setLabel('bottom', 'Time', units='s')
+        self.melody_plot.setLabel('left', 'Pitch')
+        self.melody_plot.setLimits(xMin=0, yMin=0, yMax=127)
+        self.melody_plot.showGrid(x=True, y=True, alpha=0.3)
+        self.perc_plot = self.addPlot(row=1, col=0)
+        self.perc_plot.setXLink(self.melody_plot)
+        self.perc_plot.setLabel('bottom', 'Time', units='s')
+        self.perc_plot.setLimits(xMin=0, yMin=0, yMax=1)
+        self.perc_plot.hideAxis('left')
+        self.perc_plot.showGrid(x=True, alpha=0.3)
+        self.plot = self.melody_plot
 
-    def display(self, segments):
-        self.plot.clear()
+    def clear(self):
+        self.melody_plot.clear()
+        self.perc_plot.clear()
+
+    def display(self, segments: List[SegmentAnalysis], percussion: List[PercussionEvent]):
+        self.clear()
         colors = {
             'Intro': (100, 51, 162),
             'Mid': (51, 162, 100),
@@ -29,4 +42,14 @@ class PianoRollWidget(pg.GraphicsLayoutWidget):
                 rect = QtWidgets.QGraphicsRectItem(note.start, pitch, note.duration, 1)
                 rect.setBrush(brush)
                 rect.setPen(pg.mkPen(None))
-                self.plot.addItem(rect)
+                self.melody_plot.addItem(rect)
+        perc_colors = {
+            'Kick': 'b',
+            'Snare/Clap': 'r',
+            'Hi-hat': 'y',
+        }
+        for event in percussion:
+            pen = pg.mkPen(perc_colors.get(event.hit_type, 'w'), width=2)
+            line = pg.InfiniteLine(event.time, angle=90, pen=pen)
+            line.setToolTip(f"{event.time:.2f}s - {event.hit_type}")
+            self.perc_plot.addItem(line)


### PR DESCRIPTION
## Summary
- detect percussion hits via HPSS, onset detection, and frequency band energy
- display percussion timeline alongside melody with color-coded markers
- wire GUI to show percussion events and reset properly

## Testing
- `python -m py_compile song_analyzer/analysis.py song_analyzer/piano_roll.py song_analyzer/gui.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e000050bc8323943d435210420fef