### PR TITLE
Add MIDI pitch data to note events

### DIFF
--- a/song_analyzer/analysis.py
+++ b/song_analyzer/analysis.py
@@ -8,6 +8,7 @@ class NoteEvent:
     name: str
     start: float
     duration: float
+    midi: int
 
 @dataclass
 class SegmentAnalysis:
@@ -57,10 +58,12 @@ def _group_notes(times: np.ndarray, notes: np.ndarray, offset: float) -> List[No
     start_time = times[0]
     for n, t in zip(notes[1:], times[1:]):
         if n != current:
-            events.append(NoteEvent(current, start_time + offset, t - start_time))
+            midi_val = int(librosa.note_to_midi(current))
+            events.append(NoteEvent(current, start_time + offset, t - start_time, midi_val))
             current = n
             start_time = t
-    events.append(NoteEvent(current, start_time + offset, times[-1] - start_time))
+    midi_val = int(librosa.note_to_midi(current))
+    events.append(NoteEvent(current, start_time + offset, times[-1] - start_time, midi_val))
     return events
 
 

--- a/song_analyzer/midi_export.py
+++ b/song_analyzer/midi_export.py
@@ -24,11 +24,10 @@ def export_midi(segments: Iterable['SegmentAnalysis'], path: str) -> None:
     instrument = pretty_midi.Instrument(program=0)
     for seg in segments:
         for note in seg.notes:
-            pitch = pretty_midi.note_name_to_number(note.name)
             start = note.start
             end = note.start + note.duration
             instrument.notes.append(
-                pretty_midi.Note(velocity=100, pitch=pitch, start=start, end=end)
+                pretty_midi.Note(velocity=100, pitch=note.midi, start=start, end=end)
             )
     pm.instruments.append(instrument)
     pm.write(path)

--- a/song_analyzer/piano_roll.py
+++ b/song_analyzer/piano_roll.py
@@ -1,6 +1,5 @@
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtWidgets
-import librosa
 from typing import List
 from .analysis import SegmentAnalysis, PercussionEvent
 
@@ -38,8 +37,7 @@ class PianoRollWidget(pg.GraphicsLayoutWidget):
             color = colors.get(seg.name, (200, 200, 200))
             brush = pg.mkBrush(*color)
             for note in seg.notes:
-                pitch = librosa.note_to_midi(note.name)
-                rect = QtWidgets.QGraphicsRectItem(note.start, pitch, note.duration, 1)
+                rect = QtWidgets.QGraphicsRectItem(note.start, note.midi, note.duration, 1)
                 rect.setBrush(brush)
                 rect.setPen(pg.mkPen(None))
                 self.melody_plot.addItem(rect)


### PR DESCRIPTION
## Summary
- include MIDI note number in `NoteEvent`
- compute MIDI values when grouping notes and expose them to consumers
- update MIDI export and piano roll to use stored MIDI values

## Testing
- `python -m py_compile song_analyzer/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e013d189883238a332eb273d50cca